### PR TITLE
fix examples to build. restore the (deprecated) create_torrent constructor

### DIFF
--- a/examples/connection_tester.cpp
+++ b/examples/connection_tester.cpp
@@ -723,8 +723,6 @@ void print_usage()
 		"    options for this command:\n"
 		"    -s <size>          the size of the torrent in megabytes\n"
 		"    -n <num-files>     the number of files in the test torrent\n"
-		"    -a                 introduce a lot of pad-files\n"
-		"                       (pad files are not supported for gen-data or upload)\n"
 		"    -t <file>          the file to save the .torrent file to\n"
 		"    -T <name>          the name of the torrent (and directory\n"
 		"                       its files are saved in)\n\n"
@@ -781,7 +779,7 @@ void hasher_thread(lt::create_torrent* t, piece_index_t const start_piece
 
 // size is in megabytes
 void generate_torrent(std::vector<char>& buf, int num_pieces, int num_files
-	, char const* torrent_name, bool with_padding)
+	, char const* torrent_name)
 {
 	file_storage fs;
 	// 1 MiB piece size
@@ -801,7 +799,7 @@ void generate_torrent(std::vector<char>& buf, int num_pieces, int num_files
 		file_size += 200;
 	}
 
-	lt::create_torrent t(fs, piece_size, with_padding ? 100 : -1);
+	lt::create_torrent t(fs, piece_size);
 
 	num_pieces = t.num_pieces();
 
@@ -929,7 +927,6 @@ int main(int argc, char* argv[])
 	char const* destination_ip = "127.0.0.1";
 	int destination_port = 6881;
 	int churn = 0;
-	bool gen_pad_files = false;
 
 	argv += 2;
 	argc -= 2;
@@ -950,7 +947,6 @@ int main(int argc, char* argv[])
 		switch (optname[1])
 		{
 			case 'C': test_corruption = true; continue;
-			case 'a': gen_pad_files = true; continue;
 		}
 
 		if (argc == 0)
@@ -985,7 +981,7 @@ int main(int argc, char* argv[])
 		name = name.substr(0, name.find_last_of('.'));
 		std::printf("generating torrent: %s\n", name.c_str());
 		generate_torrent(tmp, size ? size : 1024, num_files ? num_files : 1
-			, name.c_str(), gen_pad_files);
+			, name.c_str() );
 
 		FILE* output = stdout;
 		if ("-"_sv != torrent_file)
@@ -1115,7 +1111,7 @@ int main(int argc, char* argv[])
 		if (test_mode == upload_test) seed = true;
 		else if (test_mode == dual_test) seed = (i & 1);
 		conns.push_back(new peer_conn(ios[i % num_threads], ti.num_pieces(), ti.piece_length() / 16 / 1024
-			, ep, (char const*)&ti.info_hash()[0], seed, churn, corrupt));
+			, ep, (char const*)ti.info_hash().v1.data(), seed, churn, corrupt));
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		ios[i % num_threads].poll_one();
 	}

--- a/examples/custom_storage.cpp
+++ b/examples/custom_storage.cpp
@@ -44,10 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 // -- example begin
 struct temp_storage
 {
-	temp_storage(int const p_size, std::int64_t const total_size)
-		: m_piece_size(p_size)
-		, m_total_size(total_size)
-	{}
+	temp_storage(lt::file_storage const& fs) : m_files(fs) {}
 
 	lt::span<char const> readv(lt::piece_index_t const piece, int const offset, lt::storage_error& ec) const
 	{
@@ -79,7 +76,8 @@ struct temp_storage
 		TORRENT_ASSERT(offset + b.size() <= int(data.size()));
 		std::memcpy(data.data() + offset, b.data(), b.size());
 	}
-	lt::sha1_hash hash(lt::piece_index_t const piece, lt::storage_error& ec) const
+	lt::sha1_hash hash(lt::piece_index_t const piece
+		, lt::span<lt::sha256_hash> const chunk_hashes, lt::storage_error& ec) const
 	{
 		auto const i = m_file_data.find(piece);
 		if (i == m_file_data.end())
@@ -88,18 +86,51 @@ struct temp_storage
 			ec.ec = boost::asio::error::eof;
 			return {};
 		};
-		return lt::hasher(i->second.data(), int(i->second.size())).final();
+		if (!chunk_hashes.empty())
+		{
+			int const piece_size2 = m_files.piece_size2(piece);
+			int const blocks_in_piece2 = (piece_size2 + lt::default_block_size - 1) / lt::default_block_size;
+			char const* buf = i->second.data();
+			std::int64_t offset = 0;
+			for (int i = 0; i < blocks_in_piece2; ++i)
+			{
+				lt::hasher256 h2;
+				std::ptrdiff_t const len2 = std::min(lt::default_block_size, int(piece_size2 - offset));
+				h2.update({ buf, len2 });
+				buf += len2;
+				offset += len2;
+				chunk_hashes[i] = h2.final();
+			}
+		}
+		return lt::hasher(i->second).final();
 	}
+	lt::sha256_hash hash2(lt::piece_index_t const piece, int const offset, lt::storage_error& ec)
+	{
+		auto const i = m_file_data.find(piece);
+		if (i == m_file_data.end())
+		{
+			ec.operation = lt::operation_t::file_read;
+			ec.ec = boost::asio::error::eof;
+			return {};
+		};
+
+		int const piece_size = m_files.piece_size2(piece);
+
+		std::ptrdiff_t const len = std::min(lt::default_block_size, piece_size - offset);
+
+		lt::span<char const> b = {i->second.data() + offset, len};
+		return lt::hasher256(b).final();
+	}
+
 private:
 	int piece_size(lt::piece_index_t piece) const
 	{
-		int const num_pieces = static_cast<int>((m_total_size + m_piece_size - 1) / m_piece_size);
+		int const num_pieces = static_cast<int>((m_files.total_size() + m_files.piece_length() - 1) / m_files.piece_length());
 		return static_cast<int>(piece) < num_pieces - 1
-			? m_piece_size : static_cast<int>(m_total_size - (num_pieces - 1) * m_piece_size);
+			? m_files.piece_length() : static_cast<int>(m_files.total_size() - (num_pieces - 1) * m_files.piece_length());
 	}
 
-	int m_piece_size;
-	std::int64_t m_total_size;
+	lt::file_storage const& m_files;
 	std::map<lt::piece_index_t, std::vector<char>> m_file_data;
 };
 
@@ -126,8 +157,7 @@ struct temp_disk_io final : lt::disk_interface
 		lt::storage_index_t const idx = m_free_slots.empty()
 			? m_torrents.end_index()
 			: pop(m_free_slots);
-			auto storage = std::make_unique<temp_storage>(
-			params.files.piece_length(), params.files.total_size());
+			auto storage = std::make_unique<temp_storage>(params.files);
 		if (idx == m_torrents.end_index()) m_torrents.emplace_back(std::move(storage));
 		else m_torrents[idx] = std::move(storage);
 		return lt::storage_holder(idx, *this);
@@ -168,11 +198,21 @@ struct temp_disk_io final : lt::disk_interface
 		return false;
 	}
 
-	void async_hash(lt::storage_index_t storage, lt::piece_index_t const piece, lt::disk_job_flags_t
+	void async_hash(lt::storage_index_t storage, lt::piece_index_t const piece
+		, lt::span<lt::sha256_hash> chunk_hashes, lt::disk_job_flags_t
 		, std::function<void(lt::piece_index_t, lt::sha1_hash const&, lt::storage_error const&)> handler) override
 	{
 		lt::storage_error error;
-		lt::sha1_hash const hash = m_torrents[storage]->hash(piece, error);
+		lt::sha1_hash const hash = m_torrents[storage]->hash(piece, chunk_hashes, error);
+		post(m_ioc, [=]{ handler(piece, hash, error); });
+	}
+
+	void async_hash2(lt::storage_index_t storage, lt::piece_index_t const piece
+		, int const offset, lt::disk_job_flags_t
+		, std::function<void(lt::piece_index_t, lt::sha256_hash const&, lt::storage_error const&)> handler) override
+	{
+		lt::storage_error error;
+		lt::sha256_hash const hash = m_torrents[storage]->hash2(piece, offset, error);
 		post(m_ioc, [=]{ handler(piece, hash, error); });
 	}
 

--- a/include/libtorrent/create_torrent.hpp
+++ b/include/libtorrent/create_torrent.hpp
@@ -177,6 +177,13 @@ namespace libtorrent {
 			, create_flags_t flags = {});
 		explicit create_torrent(torrent_info const& ti);
 
+#if TORRENT_ABI_VERSION <= 2
+		TORRENT_DEPRECATED
+		explicit create_torrent(file_storage& fs, int piece_size
+			, int, create_flags_t flags = {}, int = -1)
+			: create_torrent(fs, piece_size, flags) {}
+#endif
+
 		// internal
 		~create_torrent();
 

--- a/include/libtorrent/info_hash.hpp
+++ b/include/libtorrent/info_hash.hpp
@@ -73,6 +73,12 @@ namespace libtorrent
 			return has_v2() ? get(protocol_version::V2) : v1;
 		}
 
+		friend bool operator!=(info_hash_t const& lhs, info_hash_t const& rhs)
+		{ return std::tie(lhs.v1, lhs.v2) != std::tie(rhs.v1, rhs.v2); }
+
+		friend bool operator==(info_hash_t const& lhs, info_hash_t const& rhs)
+		{ return std::tie(lhs.v1, lhs.v2) == std::tie(rhs.v1, rhs.v2); }
+
 		template <typename F>
 		void for_each(F func) const
 		{


### PR DESCRIPTION
update custom_storage example. make info_hash_t comparable