### PR TITLE
clean up (apparent) left over cruft in magnet_uri.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -952,7 +952,11 @@ TEST_TORRENTS = \
   url_seed_multi_single_file.torrent \
   url_seed_multi_space.torrent \
   url_seed_multi_space_nolist.torrent \
-  whitespace_url.torrent
+  whitespace_url.torrent \
+  v2.torrent \
+  v2_invalid_file.torrent \
+  v2_multipiece_file.torrent \
+  v2_only.torrent
 
 MUTABLE_TEST_TORRENTS = \
   test1.torrent \

--- a/src/magnet_uri.cpp
+++ b/src/magnet_uri.cpp
@@ -164,40 +164,6 @@ namespace libtorrent {
 		if (paused) params.flags |= add_torrent_params::flag_paused;
 		else params.flags &= ~add_torrent_params::flag_paused;
 
-#if 0
-<<<<<<< HEAD
-||||||| parent of 1eabd0c54... add info hash type
-		error_code ec;
-		string_view display_name = url_has_argument(uri, "dn");
-		if (!display_name.empty()) params.name = unescape_string(display_name, ec);
-		string_view tracker_string = url_has_argument(uri, "tr");
-		if (!tracker_string.empty()) params.trackers.push_back(unescape_string(tracker_string, ec));
-
-		string_view btih = url_has_argument(uri, "xt");
-		if (btih.empty()) return torrent_handle();
-
-		if (btih.substr(0, 9) != "urn:btih:") return torrent_handle();
-
-		if (btih.size() == 40 + 9) aux::from_hex({&btih[9], 40}, params.info_hash.data());
-		else params.info_hash.assign(base32decode(btih.substr(9)).c_str());
-
-=======
-		error_code ec;
-		string_view display_name = url_has_argument(uri, "dn");
-		if (!display_name.empty()) params.name = unescape_string(display_name, ec);
-		string_view tracker_string = url_has_argument(uri, "tr");
-		if (!tracker_string.empty()) params.trackers.push_back(unescape_string(tracker_string, ec));
-
-		string_view btih = url_has_argument(uri, "xt");
-		if (btih.empty()) return torrent_handle();
-
-		if (btih.substr(0, 9) != "urn:btih:") return torrent_handle();
-
-		if (btih.size() == 40 + 9) aux::from_hex({&btih[9], 40}, params.info_hash.v1.data());
-		else params.info_hash.v1.assign(base32decode(btih.substr(9)).c_str());
-
->>>>>>> 1eabd0c54... add info hash type
-#endif
 		return ses.add_torrent(std::move(params));
 	}
 
@@ -291,7 +257,7 @@ namespace libtorrent {
 					value = value.substr(9);
 
 					sha1_hash info_hash;
-					if (value.size() == 40) aux::from_hex({ value.data(), 40 }, info_hash.data());
+					if (value.size() == 40) aux::from_hex(value, info_hash.data());
 					else if (value.size() == 32)
 					{
 						std::string const ih = base32decode(value);
@@ -323,14 +289,12 @@ namespace libtorrent {
 
 					value = value.substr(4);
 
-					sha256_hash info_hash;
-					if (value.size() == 64) aux::from_hex({ value.data(), 64 }, info_hash.data());
-					else
+					if (value.size() != 64)
 					{
 						ec = errors::invalid_info_hash;
 						return;
 					}
-					p.info_hash.v2 = info_hash;
+					aux::from_hex(value, p.info_hash.v2.data());
 					has_ih[1] = true;
 				}
 			}

--- a/test/test_magnet.cpp
+++ b/test/test_magnet.cpp
@@ -307,6 +307,21 @@ TORRENT_TEST(parse_v2_hash)
 {
 	add_torrent_params p = parse_magnet_uri("magnet:?xt=urn:btmh:1220cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
 	TEST_EQUAL(aux::to_hex(p.info_hash.v2), "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd");
+	TEST_EQUAL(aux::to_hex(p.info_hash.v1), "0000000000000000000000000000000000000000");
+}
+
+TORRENT_TEST(parse_v2_short_hash)
+{
+	error_code ec;
+	add_torrent_params p = parse_magnet_uri("magnet:?xt=urn:btmh:1220cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdccdcdcdcdcdcdcd", ec);
+	TEST_EQUAL(ec, error_code(errors::invalid_info_hash));
+}
+
+TORRENT_TEST(parse_v2_invalid_hash_prefix)
+{
+	error_code ec;
+	add_torrent_params p = parse_magnet_uri("magnet:?xt=urn:btmh:1221cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", ec);
+	TEST_EQUAL(ec, error_code(errors::invalid_info_hash));
 }
 
 TORRENT_TEST(parse_hybrid_uri)

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -163,6 +163,7 @@ test_failing_torrent_t test_error_torrents[] =
 	{ "invalid_symlink.torrent", errors::torrent_invalid_name },
 	{ "many_pieces.torrent", errors::too_many_pieces_in_torrent },
 	{ "no_files.torrent", errors::no_files_in_torrent},
+	{ "v2_invalid_file.torrent", errors::torrent_file_parse_failed},
 };
 
 } // anonymous namespace
@@ -830,6 +831,36 @@ TORRENT_TEST(parse_torrents)
 		{
 			TEST_EQUAL(ti->num_files(), 3);
 		}
+		else if (t.file == "v2.torrent"_sv)
+		{
+			TEST_EQUAL(ti->num_files(), 1);
+			TEST_EQUAL(ti->files().file_path(file_index_t{0}), "test64K"_sv);
+			TEST_EQUAL(ti->files().file_size(file_index_t{0}), 65536);
+			TEST_EQUAL(aux::to_hex(ti->files().root(file_index_t{0})), "60aae9c7b428f87e0713e88229e18f0adf12cd7b22a0dd8a92bb2485eb7af242"_sv);
+			TEST_EQUAL(ti->info_hash().has_v1(), true);
+			TEST_EQUAL(ti->info_hash().has_v2(), true);
+			TEST_EQUAL(aux::to_hex(ti->info_hash().v2), "597b180c1a170a585dfc5e85d834d69013ceda174b8f357d5bb1a0ca509faf0a"_sv);
+		}
+		else if (t.file == "v2_only.torrent"_sv)
+		{
+			TEST_EQUAL(ti->num_files(), 1);
+			TEST_EQUAL(ti->files().file_path(file_index_t{0}), "test1MB"_sv);
+			TEST_EQUAL(ti->files().file_size(file_index_t{0}), 1048576);
+			TEST_EQUAL(aux::to_hex(ti->files().root(file_index_t{0})), "515ea9181744b817744ded9d2e8e9dc6a8450c0b0c52e24b5077f302ffbd9008"_sv);
+			TEST_EQUAL(ti->info_hash().has_v1(), false);
+			TEST_EQUAL(ti->info_hash().has_v2(), true);
+			TEST_EQUAL(aux::to_hex(ti->info_hash().v2), "95e04d0c4bad94ab206efa884666fd89777dbe4f7bd9945af1829037a85c6192"_sv);
+		}
+		else if (t.file == "v2_multipiece_file.torrent"_sv)
+		{
+			TEST_EQUAL(ti->num_files(), 1);
+			TEST_EQUAL(ti->files().file_path(file_index_t{0}), "test1MB"_sv);
+			TEST_EQUAL(ti->files().file_size(file_index_t{0}), 1048576);
+			TEST_EQUAL(aux::to_hex(ti->files().root(file_index_t{0})), "515ea9181744b817744ded9d2e8e9dc6a8450c0b0c52e24b5077f302ffbd9008"_sv);
+			TEST_EQUAL(ti->info_hash().has_v1(), true);
+			TEST_EQUAL(ti->info_hash().has_v2(), true);
+			TEST_EQUAL(aux::to_hex(ti->info_hash().v2), "108ac2c3718ce722e6896edc56c4afa98f1d711ecaace7aad74fca418ebd03de"_sv);
+		}
 
 		file_storage const& fs = ti->files();
 		for (file_index_t idx{0}; idx != file_index_t(fs.num_files()); ++idx)
@@ -861,7 +892,7 @@ TORRENT_TEST(parse_torrents)
 			combine_path(root_dir, "test_torrents"), test_error_torrents[i].file), ec);
 		std::printf("E:        \"%s\"\nexpected: \"%s\"\n", ec.message().c_str()
 			, test_error_torrents[i].error.message().c_str());
-		TEST_CHECK(ec.message() == test_error_torrents[i].error.message());
+		TEST_EQUAL(ec.message(), test_error_torrents[i].error.message());
 		TEST_EQUAL(ti->is_valid(), false);
 	}
 }

--- a/test/test_torrents/v2_invalid_file.torrent
+++ b/test/test_torrents/v2_invalid_file.torrent
@@ -1,0 +1,2 @@
+d8:announce27:http://example.com/announce4:infod9:file treed7:test64Kd6:lengthi65536e11:pieces root32:`ªéÇ´(ø~è‚)á
+ßÍ{" İŠ’»$…ëzòBee6:lengthi65536e12:meta versioni2e4:name7:test64K12:piece lengthi65536e6:pieces20:Ü•¾¾êŒ-@Í«zuÄùae12:piece layersdee


### PR DESCRIPTION
minor polishing. Add a few more test cases for magnet link parser as well as torrent_info parser.