### PR TITLE
limit piece size to avoid overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -960,7 +960,8 @@ TEST_TORRENTS = \
   v2_mismatching_metadata.torrent \
   v2_invalid_filename.torrent \
   v2_no_piece_layers.torrent \
-  v2_large_file.torrent
+  v2_large_file.torrent \
+  v2_piece_size.torrent
 
 MUTABLE_TEST_TORRENTS = \
   test1.torrent \

--- a/src/torrent_info.cpp
+++ b/src/torrent_info.cpp
@@ -1151,7 +1151,12 @@ namespace {
 
 		// extract piece length
 		std::int64_t piece_length = info.dict_find_int_value("piece length", -1);
-		if (piece_length <= 0 || piece_length > std::numeric_limits<int>::max())
+		// limit the piece length at INT_MAX / 2 to get a bit of headroom. We
+		// commonly compute the number of blocks per pieces by adding
+		// block_size - 1 before dividing by block_size. That would overflow with
+		// a piece size of INT_MAX. This limit is still an unreasonably large
+		// piece size anyway.
+		if (piece_length <= 0 || piece_length > std::numeric_limits<int>::max() / 2)
 		{
 			ec = errors::torrent_missing_piece_length;
 			return false;
@@ -1300,7 +1305,7 @@ namespace {
 		// extra addition
 
 		if (files.total_size() / files.piece_length() >=
-			std::numeric_limits<int>::max() - files.piece_length())
+			std::numeric_limits<int>::max())
 		{
 			ec = errors::too_many_pieces_in_torrent;
 			// mark the torrent as invalid

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -36,7 +36,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/torrent_info.hpp"
 #include "libtorrent/create_torrent.hpp"
 #include "libtorrent/announce_entry.hpp"
+#include "libtorrent/disk_interface.hpp" // for default_block_size
 #include "libtorrent/aux_/escape_string.hpp" // for convert_path_to_posix
+#include "libtorrent/piece_picker.hpp"
 #include "libtorrent/hex.hpp" // to_hex
 
 #include <iostream>
@@ -168,6 +170,7 @@ test_failing_torrent_t test_error_torrents[] =
 	{ "v2_invalid_file.torrent", errors::torrent_file_parse_failed},
 	{ "v2_mismatching_metadata.torrent", errors::torrent_inconsistent_files},
 	{ "v2_large_file.torrent", errors::torrent_invalid_length},
+	{ "v2_piece_size.torrent", errors::torrent_missing_piece_length},
 };
 
 } // anonymous namespace
@@ -711,6 +714,19 @@ TORRENT_TEST(parse_torrents)
 		TEST_CHECK(!ec);
 		if (ec) std::printf(" loading(\"%s\") -> failed %s\n", filename.c_str()
 			, ec.message().c_str());
+
+		// construct a piece_picker to get some more test coverage. Perhaps
+		// loading the torrent is fine, but if we can't construct a piece_picker
+		// for it, it's still no good.
+		int const block_size = std::min(ti->piece_length(), default_block_size);
+		int const blocks_per_piece
+			= (ti->piece_length() + block_size - 1) / block_size;
+		int const blocks_in_last_piece
+			= ((ti->total_size() % ti->piece_length())
+			+ block_size - 1) / block_size;
+		piece_picker pp(blocks_per_piece, blocks_in_last_piece, ti->num_pieces());
+
+		TEST_CHECK(ti->piece_length() < std::numeric_limits<int>::max() / 2);
 
 		if (t.file == "whitespace_url.torrent"_sv)
 		{

--- a/test/test_torrents/v2_piece_size.torrent
+++ b/test/test_torrents/v2_piece_size.torrent
@@ -1,0 +1,1 @@
+d8:announce27:http://example.com/announce4:infod9:file treed7:test1MBd0:d6:lengthi1048576e11:pieces root32:Q^©D¸tMí.Æ¨ERâKPwóÿ½eee12:meta versioni2e4:name7:test1MB12:piece lengthi2147483647eee


### PR DESCRIPTION
I should look into whether this should make it into `RC_1_2` as well. There's no great test for this. To trigger the overflow, it's not sufficient to just load the .torrent file, but also to construct a piece_picker from it.