### PR TITLE
copy info_hash into storage_params to avoid a dangling reference

### DIFF
--- a/include/libtorrent/storage_defs.hpp
+++ b/include/libtorrent/storage_defs.hpp
@@ -117,7 +117,7 @@ namespace libtorrent {
 		std::string const& path;
 		storage_mode_t mode{storage_mode_sparse};
 		aux::vector<download_priority_t, file_index_t> const& priorities;
-		sha1_hash const& info_hash;
+		sha1_hash info_hash;
 	};
 }
 


### PR DESCRIPTION
Specifically, the problem happens here: https://github.com/ssiloti/libtorrent/blob/v2/src/torrent.cpp#L1670
as the info_hash now is a temporary value, as opposed to a member of the torrent object.