### PR TITLE
the file root hash never has to be owned

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -162,12 +162,11 @@ namespace libtorrent {
 	private:
 		// This string is not necessarily 0-terminated!
 		// that's why it's private, to keep people away from it
-		char const* name;
+		char const* name = nullptr;
 	public:
 		// the sha256 root of the merkle tree for this file
-		// like hash, this may be a pointer into the .torrent file or
-		// an owned pointer depending on the value of root_is_owned
-		char const* root;
+		// this is a pointer into the .torrent file
+		char const* root = nullptr;
 
 		// the index into file_storage::m_paths. To get
 		// the full path to this file, concatenate the path
@@ -178,8 +177,7 @@ namespace libtorrent {
 		// path_is_absolute means the filename
 		// in this field contains the full, absolute path
 		// to the file
-		std::uint32_t path_index:30;
-		std::uint32_t root_is_owned:1;
+		std::uint32_t path_index = internal_file_entry::no_path;
 	};
 
 

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -232,10 +232,6 @@ namespace {
 		, hidden_attribute(false)
 		, executable_attribute(false)
 		, symlink_attribute(false)
-		, name(nullptr)
-		, root(nullptr)
-		, path_index(internal_file_entry::no_path)
-		, root_is_owned(0)
 	{}
 
 	internal_file_entry::~internal_file_entry()
@@ -253,21 +249,13 @@ namespace {
 		, hidden_attribute(fe.hidden_attribute)
 		, executable_attribute(fe.executable_attribute)
 		, symlink_attribute(fe.symlink_attribute)
-		, name(nullptr)
 		, root(fe.root)
 		, path_index(fe.path_index)
-		, root_is_owned(fe.root_is_owned)
 	{
 		if (fe.name_len == name_is_owned)
 			name = allocate_string_copy(fe.name);
 		else
 			name = fe.name;
-		if (fe.root_is_owned)
-		{
-			char* new_root = new char[32];
-			std::memcpy(new_root, fe.root, 32);
-			root = new_root;
-		}
 	}
 
 	internal_file_entry& internal_file_entry::operator=(internal_file_entry const& fe) &
@@ -283,21 +271,12 @@ namespace {
 		executable_attribute = fe.executable_attribute;
 		symlink_attribute = fe.symlink_attribute;
 		no_root_dir = fe.no_root_dir;
+		root = fe.root;
 
 		if (fe.name_len == name_is_owned)
 			name = allocate_string_copy(fe.name);
 		else
 			name = fe.name;
-		if (fe.root_is_owned)
-		{
-			char* new_root = new char[32];
-			std::memcpy(new_root, fe.root, 32);
-			root = new_root;
-		}
-		else
-		{
-			root = fe.root;
-		}
 
 		return *this;
 	}
@@ -315,12 +294,9 @@ namespace {
 		, name(fe.name)
 		, root(fe.root)
 		, path_index(fe.path_index)
-		, root_is_owned(fe.root_is_owned)
 	{
 		fe.name_len = name_is_owned;
 		fe.name = nullptr;
-		fe.root_is_owned = 1;
-		fe.root = nullptr;
 	}
 
 	internal_file_entry& internal_file_entry::operator=(internal_file_entry&& fe) & noexcept
@@ -338,12 +314,9 @@ namespace {
 		name = fe.name;
 		root = fe.root;
 		name_len = fe.name_len;
-		root_is_owned = fe.root_is_owned;
 
 		fe.name_len = name_is_owned;
 		fe.name = nullptr;
-		fe.root_is_owned = 1;
-		fe.root = nullptr;
 		return *this;
 	}
 
@@ -389,8 +362,9 @@ namespace {
 	{
 		for (auto& f : m_files)
 		{
-			if (f.name_len == internal_file_entry::name_is_owned) continue;
-			f.name += off;
+			if (f.name_len != internal_file_entry::name_is_owned)
+				f.name += off;
+			if (f.root != nullptr) f.root += off;
 		}
 
 		for (auto& h : m_file_hashes)
@@ -768,7 +742,7 @@ namespace {
 		return sha1_hash(m_file_hashes[index]);
 	}
 
-	sha256_hash file_storage::root(file_index_t index) const
+	sha256_hash file_storage::root(file_index_t const index) const
 	{
 		TORRENT_ASSERT_PRECOND(index >= file_index_t{} && index < end_file());
 		if (m_files[index].root == nullptr) return sha256_hash();

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -181,14 +181,18 @@ TORRENT_TEST(pointer_offset)
 	// test applying pointer offset
 	file_storage st;
 	char const filename[] = "test1fooba";
+	char const filehash[] = "01234567890123456789-----";
+	char const roothash[] = "01234567890123456789012345678912-----";
 
 	st.add_file_borrow({filename, 5}, combine_path("test-torrent-1", "test1")
-		, 10);
+		, 10, file_flags_t{}, filehash, 0, {}, roothash);
 
 	// test filename_ptr and filename_len
 	TEST_EQUAL(st.file_name_ptr(file_index_t{0}), filename);
 	TEST_EQUAL(st.file_name_len(file_index_t{0}), 5);
 	TEST_EQUAL(st.file_name(file_index_t{0}), string_view(filename, 5));
+	TEST_EQUAL(st.hash(file_index_t{0}), sha1_hash(filehash));
+	TEST_EQUAL(st.root(file_index_t{0}), sha256_hash(roothash));
 
 	TEST_EQUAL(st.file_path(file_index_t{0}, ""), combine_path("test-torrent-1", "test1"));
 	TEST_EQUAL(st.file_path(file_index_t{0}, "tmp"), combine_path("tmp"
@@ -206,6 +210,9 @@ TORRENT_TEST(pointer_offset)
 	// test filename_ptr and filename_len
 	TEST_EQUAL(st.file_name_ptr(file_index_t{0}), filename + 5);
 	TEST_EQUAL(st.file_name_len(file_index_t{0}), 5);
+	TEST_EQUAL(st.file_name(file_index_t{0}), string_view(filename + 5, 5));
+	TEST_EQUAL(st.hash(file_index_t{0}), sha1_hash(filehash + 5));
+	TEST_EQUAL(st.root(file_index_t{0}), sha256_hash(roothash + 5));
 }
 
 TORRENT_TEST(invalid_path1)


### PR DESCRIPTION
It never changes. as far as I can tell, the previous code also wasn't correct. I don't see any place where the owned root hash is deleted. But I don't think it has to be that complicated, as long as the root hash pointers are updated when the metadata buffer moves (in `apply_pointer_offset()`)