### PR TITLE
don't pad the tail of v2 torrents

### DIFF
--- a/src/create_torrent.cpp
+++ b/src/create_torrent.cpp
@@ -785,6 +785,17 @@ namespace {
 					file_e["length"] = m_files.file_size(i);
 					file_e["pieces root"] = m_fileroots[i];
 					if (m_include_mtime && m_files.mtime(i)) file_e["mtime"] = m_files.mtime(i);
+
+					file_flags_t const flags = m_files.file_flags(i);
+					if (flags & (file_storage::flag_hidden
+						| file_storage::flag_executable
+						| file_storage::flag_symlink))
+					{
+						std::string& attr = file_e["attr"].string();
+						if (flags & file_storage::flag_hidden) attr += 'h';
+						if (flags & file_storage::flag_executable) attr += 'x';
+						if (m_include_symlinks && (flags & file_storage::flag_symlink)) attr += 'l';
+					}
 				}
 			}
 		}


### PR DESCRIPTION
while testing this I also noticed attributes were not supported by create_torrent for v2 torrents, so I added that.

Som parts of this patch is probably easiest to view ignoring whitespace.