### PR TITLE
add tests that ordering of files in file tree is enforced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -973,7 +973,9 @@ TEST_TORRENTS = \
   v2_no_piece_layers.torrent \
   v2_large_file.torrent \
   v2_large_offset.torrent \
-  v2_piece_size.torrent
+  v2_piece_size.torrent \
+  v2_unordered_files.torrent \
+  v2_overlong_integer.torrent
 
 MUTABLE_TEST_TORRENTS = \
   test1.torrent \

--- a/test/test_torrent_info.cpp
+++ b/test/test_torrent_info.cpp
@@ -182,6 +182,8 @@ test_failing_torrent_t test_error_torrents[] =
 	{ "v2_no_piece_layers.torrent", errors::torrent_missing_piece_layer},
 	{ "v2_large_offset.torrent", errors::too_many_pieces_in_torrent},
 	{ "v2_piece_size.torrent", errors::torrent_missing_piece_length},
+	{ "v2_unordered_files.torrent", errors::invalid_bencoding},
+	{ "v2_overlong_integer.torrent", errors::invalid_bencoding},
 };
 
 } // anonymous namespace

--- a/test/test_torrents/v2_overlong_integer.torrent
+++ b/test/test_torrents/v2_overlong_integer.torrent
@@ -1,0 +1,2 @@
+d10:created by10:libtorrent13:creation datei1556473052e4:infod9:file treed9:test1.txtd0:d6:lengthi07e11:pieces root32:®Àpd_å>ã³v0Y7a4ğXÌ3rGÉx­Ñx¶Ìß°Ÿee9:test2.txtd0:d6:lengthi7e11:pieces root32:f­$
+Ãô„®UêÉbónœ±æ€Ê8×H¡ee9:test3.txtd0:d6:lengthi7e11:pieces root32:ş/ŸRÂ[íbŒ¸nÒ…œç={6oNµîæÅ°™VShÖeee12:meta versioni2e4:name4:test12:piece lengthi16384ee12:piece layersdee

--- a/test/test_torrents/v2_unordered_files.torrent
+++ b/test/test_torrents/v2_unordered_files.torrent
@@ -1,0 +1,2 @@
+d10:created by10:libtorrent13:creation datei1556472816e4:infod9:file treed9:test2.txtd0:d6:lengthi7e11:pieces root32:f­$
+Ãô„®UêÉbónœ±æ€Ê8×H¡ee9:test1.txtd0:d6:lengthi7e11:pieces root32:®Àpd_å>ã³v0Y7a4ğXÌ3rGÉx­Ñx¶Ìß°Ÿee9:test3.txtd0:d6:lengthi7e11:pieces root32:ş/ŸRÂ[íbŒ¸nÒ…œç={6oNµîæÅ°™VShÖeee12:meta versioni2e4:name4:test12:piece lengthi16384ee12:piece layersdee


### PR DESCRIPTION
as well as a test that "overlong" integer encodings are rejected