### PR TITLE
disallow mixing v1 and v2 torrents when building a file_storage

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -588,10 +588,14 @@ namespace libtorrent {
 
 		// the number of bytes in a regular piece
 		// (i.e. not the potentially truncated last piece)
-		int m_piece_length;
+		int m_piece_length = 0;
 
 		// the number of pieces in the torrent
-		int m_num_pieces;
+		int m_num_pieces = 0;
+
+		// whether this is a v2 torrent or not. Additional requirements apply to
+		// v2 torrents
+		bool m_v2 = false;
 
 		void update_path_index(internal_file_entry& e, std::string const& path
 			, bool set_name = true);
@@ -633,7 +637,7 @@ namespace libtorrent {
 		std::string m_name;
 
 		// the sum of all file sizes
-		std::int64_t m_total_size;
+		std::int64_t m_total_size = 0;
 	};
 
 namespace aux {

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -71,11 +71,7 @@ namespace libtorrent {
 	constexpr file_flags_t file_storage::attribute_symlink;
 #endif
 
-	file_storage::file_storage()
-		: m_piece_length(0)
-		, m_num_pieces(0)
-		, m_total_size(0)
-	{}
+	file_storage::file_storage() {}
 
 	file_storage::~file_storage() = default;
 
@@ -684,6 +680,20 @@ namespace {
 		{
 			if (m_files.empty())
 				m_name = lsplit_path(path).first.to_string();
+		}
+
+		bool const v2 = (root_hash != nullptr);
+		if (m_files.empty())
+		{
+			m_v2 = v2;
+		}
+		else if (m_v2 != v2)
+		{
+			// you cannot mix v1 and v2 files when building torrent_storage. Either
+			// all files are v1 or all files are v2
+			ec = m_v2 ? make_error_code(errors::torrent_missing_pieces_root)
+				: make_error_code(errors::torrent_inconsistent_files);
+			return;
 		}
 
 		// a root hash implies a v2 file tree

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -781,5 +781,29 @@ TORRENT_TEST(file_first_block_node)
 	TEST_EQUAL(first_block_node(0x800001), 1023);
 }
 
+TORRENT_TEST(mismatching_file_hash1)
+{
+	file_storage st;
+	st.set_piece_length(0x4000);
+
+	error_code ec;
+	st.add_file(ec, combine_path("test", "a"), 10000);
+	TEST_CHECK(!ec);
+	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, "abababababababababababababababab");
+	TEST_CHECK(ec);
+}
+
+TORRENT_TEST(mismatching_file_hash2)
+{
+	file_storage st;
+	st.set_piece_length(0x4000);
+
+	error_code ec;
+	st.add_file(ec, combine_path("test", "B"), 10000, {}, 0, {}, "abababababababababababababababab");
+	TEST_CHECK(!ec);
+	st.add_file(ec, combine_path("test", "a"), 10000);
+	TEST_CHECK(ec);
+}
+
 // TODO: test file attributes
 // TODO: test symlinks


### PR DESCRIPTION
whether the torrent is v2 or v1 is currently determined each time `add_file` is called. This patch makes sure separate calls must be consistent in whether they are v1 or v2.