### PR TITLE
convert file merkle trees to use aux::vector instead of std::vector

### DIFF
--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -123,7 +123,7 @@ namespace libtorrent
 	{
 	public:
 		hash_picker(file_storage const& files
-			, aux::vector<std::vector<sha256_hash>, file_index_t>& trees
+			, aux::vector<aux::vector<sha256_hash>, file_index_t>& trees
 			, aux::vector<std::vector<bool>, file_index_t> verified = {}
 			, bool all_verified = false);
 
@@ -192,7 +192,7 @@ namespace libtorrent
 		};
 
 		file_storage const& m_files;
-		aux::vector<std::vector<sha256_hash>, file_index_t>& m_merkle_trees;
+		aux::vector<aux::vector<sha256_hash>, file_index_t>& m_merkle_trees;
 		aux::vector<std::vector<bool>, file_index_t> m_hash_verified;
 		aux::vector<std::vector<piece_hash_request>, file_index_t> m_piece_hash_requested;
 		// blocks are only added to this list if there is a time critial block which

--- a/include/libtorrent/torrent_info.hpp
+++ b/include/libtorrent/torrent_info.hpp
@@ -542,8 +542,8 @@ namespace libtorrent {
 		boost::shared_array<char> metadata() const
 		{ return m_info_section; }
 
-		aux::vector<std::vector<sha256_hash>, file_index_t>& merkle_trees();
-		std::vector<sha256_hash>& file_merkle_tree(file_index_t file) const;
+		aux::vector<aux::vector<sha256_hash>, file_index_t>& merkle_trees();
+		aux::vector<sha256_hash>& file_merkle_tree(file_index_t file) const;
 
 #if TORRENT_ABI_VERSION <= 2
 		// support for BEP 30 merkle torrents has been removed
@@ -635,7 +635,7 @@ namespace libtorrent {
 #endif
 
 		// v2 merkle tree for each file
-		mutable aux::vector<std::vector<sha256_hash>, file_index_t> m_merkle_trees;
+		mutable aux::vector<aux::vector<sha256_hash>, file_index_t> m_merkle_trees;
 
 		// this is a copy of the info section from the torrent.
 		// it use maintained in this flat format in order to

--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -89,7 +89,7 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 }
 
 	hash_picker::hash_picker(file_storage const& files
-		, aux::vector<std::vector<sha256_hash>, file_index_t>& trees
+		, aux::vector<aux::vector<sha256_hash>, file_index_t>& trees
 		, aux::vector<std::vector<bool>, file_index_t> verified
 		, bool all_verified)
 		: m_files(files)

--- a/src/read_resume_data.cpp
+++ b/src/read_resume_data.cpp
@@ -139,7 +139,7 @@ namespace {
 				if (!dh || dh.string_length() % 32 != 0) break;
 
 				ret.merkle_trees.emplace_back();
-				ret.merkle_trees.back().reserve(dh.string_length() / 32);
+				ret.merkle_trees.back().reserve(dh.string_value().size() / 32);
 				for (auto hashes = dh.string_value();
 					!hashes.empty(); hashes = hashes.substr(32))
 				{

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -714,6 +714,7 @@ TORRENT_TEST(file_num_pieces)
 	TEST_EQUAL(fs.file_num_pieces(file_index_t{7}), 1);
 }
 
+namespace {
 int first_piece_node(int piece_size, int file_size)
 {
 	file_storage fs;
@@ -732,6 +733,7 @@ int first_block_node(int file_size)
 	int const num_pieces = (int(fs.total_size()) + fs.piece_length() - 1) / fs.piece_length();
 	fs.set_num_pieces(num_pieces);
 	return fs.file_first_block_node(file_index_t{0});
+}
 }
 
 TORRENT_TEST(file_first_piece_node)

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -85,11 +85,11 @@ TORRENT_TEST(pick_piece_layer)
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 	fs.add_file("test/tmp2", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
 
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
 
 	hash_picker picker(fs, trees);
@@ -160,8 +160,8 @@ TORRENT_TEST(reject_piece_request)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
 
 	hash_picker picker(fs, trees);
@@ -184,10 +184,10 @@ TORRENT_TEST(add_leaf_hashes)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 512; i++)
 	{
@@ -241,10 +241,10 @@ TORRENT_TEST(add_piece_hashes)
 
 	fs.add_file("test/tmp1", 4 * 1024 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 1024))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 1024))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 1024; i++)
 	{
@@ -281,10 +281,10 @@ TORRENT_TEST(add_bad_hashes)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 512; i++)
 	{
@@ -341,10 +341,10 @@ TORRENT_TEST(bad_block_hash)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 512; i++)
 	{
@@ -387,10 +387,10 @@ TORRENT_TEST(set_block_hash)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 512; i++)
 	{
@@ -437,10 +437,10 @@ TORRENT_TEST(pass_piece)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 
-	std::vector<sha256_hash> full_tree(trees.front().size());
+	aux::vector<sha256_hash> full_tree(trees.front().size());
 
 	for (int i = 0; i < 4 * 512; i++)
 	{
@@ -483,8 +483,8 @@ TORRENT_TEST(only_pick_have_pieces)
 
 	fs.add_file("test/tmp1", 4 * 512 * 16 * 1024);
 
-	aux::vector<std::vector<sha256_hash>, file_index_t> trees;
-	trees.push_back(std::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
+	aux::vector<aux::vector<sha256_hash>, file_index_t> trees;
+	trees.push_back(aux::vector<sha256_hash>(merkle_num_nodes(merkle_num_leafs(4 * 512))));
 	aux::from_hex("0000000000000000000000000000000000000000000000000000000000000001", trees.back()[0].data());
 
 	hash_picker picker(fs, trees);

--- a/test/test_merkle.cpp
+++ b/test/test_merkle.cpp
@@ -356,7 +356,7 @@ TORRENT_TEST(merkle_root)
 namespace {
 void print_tree(span<sha256_hash const> tree)
 {
-	int const num_leafs = (tree.size() + 1) / 2;
+	int const num_leafs = static_cast<int>((tree.size() + 1) / 2);
 	int spacing = num_leafs;
 	int const num_levels = merkle_num_layers(num_leafs) + 1;
 	int layer_width = 1;


### PR DESCRIPTION
and use orig_files() instead of m_files when sizing the file hash trees, to avoid getting it wrong because of a remap_files() call