### PR TITLE
use a strong type for the index into m_paths in file_storage

### DIFF
--- a/include/libtorrent/file_storage.hpp
+++ b/include/libtorrent/file_storage.hpp
@@ -49,6 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "libtorrent/index_range.hpp"
 #include "libtorrent/flags.hpp"
 #include "libtorrent/error_code.hpp"
+#include "libtorrent/units.hpp"
 
 namespace libtorrent {
 
@@ -109,6 +110,11 @@ namespace libtorrent {
 
 #endif // TORRENT_ABI_VERSION
 
+namespace aux {
+	struct path_index_tag;
+	using path_index_t = aux::strong_typedef<std::uint32_t, path_index_tag>;
+}
+
 	// internal
 	struct internal_file_entry
 	{
@@ -131,9 +137,10 @@ namespace libtorrent {
 		enum {
 			name_is_owned = (1 << 12) - 1,
 			not_a_symlink = (1 << 15) - 1,
-			no_path = (1 << 30) - 1,
-			path_is_absolute = (1 << 30) - 2,
 		};
+
+		static constexpr aux::path_index_t no_path{(1 << 30) - 1};
+		static constexpr aux::path_index_t path_is_absolute{(1 << 30) - 2};
 
 		// the offset of this file inside the torrent
 		std::uint64_t offset:48;
@@ -179,7 +186,7 @@ namespace libtorrent {
 		// path_is_absolute means the filename
 		// in this field contains the full, absolute path
 		// to the file
-		std::uint32_t path_index = internal_file_entry::no_path;
+		aux::path_index_t path_index = internal_file_entry::no_path;
 	};
 
 
@@ -520,7 +527,8 @@ namespace libtorrent {
 		// target string associated with it.
 		static constexpr file_flags_t flag_symlink = 3_bit;
 
-		std::vector<std::string> const& paths() const { return m_paths; }
+		// internal
+		aux::vector<std::string, aux::path_index_t> const& paths() const { return m_paths; }
 
 		// returns a bitmask of flags from file_flags_t that apply
 		// to file at ``index``.
@@ -584,7 +592,7 @@ namespace libtorrent {
 
 		file_index_t last_file() const noexcept;
 
-		int get_or_add_path(string_view path);
+		aux::path_index_t get_or_add_path(string_view path);
 
 		// the number of bytes in a regular piece
 		// (i.e. not the potentially truncated last piece)
@@ -626,7 +634,7 @@ namespace libtorrent {
 		// name for multi-file torrents. The m_name field need to be
 		// prepended to these paths, and the filename of a specific file
 		// entry appended, to form full file paths
-		aux::vector<std::string> m_paths;
+		aux::vector<std::string, aux::path_index_t> m_paths;
 
 		// name of torrent. For multi-file torrents
 		// this is always the root directory

--- a/src/file_storage.cpp
+++ b/src/file_storage.cpp
@@ -108,6 +108,9 @@ namespace libtorrent {
 			return piece_length();
 	}
 
+constexpr aux::path_index_t internal_file_entry::no_path;
+constexpr aux::path_index_t internal_file_entry::path_is_absolute;
+
 namespace {
 
 	bool compare_file_offset(internal_file_entry const& lhs
@@ -189,7 +192,7 @@ namespace {
 		if (set_name) e.set_name(leaf);
 	}
 
-	int file_storage::get_or_add_path(string_view const path)
+	aux::path_index_t file_storage::get_or_add_path(string_view const path)
 	{
 		// do we already have this path in the path list?
 		auto const p = std::find(m_paths.rbegin(), m_paths.rend(), path);
@@ -197,7 +200,7 @@ namespace {
 		if (p == m_paths.rend())
 		{
 			// no, we don't. add it
-			int const ret = int(m_paths.size());
+			auto const ret = m_paths.end_index();
 			TORRENT_ASSERT(path.size() == 0 || path[0] != '/');
 			m_paths.emplace_back(path.data(), path.size());
 			return ret;
@@ -205,7 +208,7 @@ namespace {
 		else
 		{
 			// yes we do. use it
-			return int(p.base() - m_paths.begin() - 1);
+			return aux::path_index_t(p.base() - m_paths.begin() - 1);
 		}
 	}
 
@@ -1103,8 +1106,8 @@ namespace {
 		// use this vector to track the new ordering of files
 		// this allows the use of STL algorthims despite them
 		// not supporting a custom swap functor
-		std::vector<file_index_t> new_order(num_files());
-		for (file_index_t i(0); i < num_files(); ++i)
+		aux::vector<file_index_t, file_index_t> new_order(num_files());
+		for (file_index_t i(0); i < end_file(); ++i)
 			new_order[i] = i;
 
 		// remove any existing pad files
@@ -1180,12 +1183,12 @@ namespace {
 			TORRENT_ASSERT(!m_files[i].pad_file);
 			new_files.emplace_back(std::move(m_files[i]));
 
-			if (int(m_file_hashes.size()) > i)
+			if (i < m_file_hashes.end_index())
 				new_file_hashes.push_back(m_file_hashes[i]);
 			else if (!m_file_hashes.empty())
 				new_file_hashes.push_back(nullptr);
 
-			if (int(m_mtime.size()) > i)
+			if (i < m_mtime.end_index())
 				new_mtime.push_back(m_mtime[i]);
 			else if (!m_mtime.empty())
 				new_mtime.push_back(0);
@@ -1252,7 +1255,7 @@ namespace {
 
 			// for backwards compatibility, allow paths relative to the link as
 			// well
-			if (fe.path_index < (1 << 29))
+			if (fe.path_index < internal_file_entry::path_is_absolute)
 			{
 				std::string target = m_paths[fe.path_index];
 				append_path(target, symlink(i));

--- a/test/test_file_storage.cpp
+++ b/test/test_file_storage.cpp
@@ -78,6 +78,9 @@ void setup_test_storage(file_storage& st)
 	TEST_EQUAL(st.num_pieces(), (100000 + 0x3fff) / 0x4000);
 }
 
+aux::path_index_t operator""_path(unsigned long long i)
+{ return aux::path_index_t(i); }
+
 } // anonymous namespace
 
 TORRENT_TEST(coalesce_path)
@@ -86,29 +89,29 @@ TORRENT_TEST(coalesce_path)
 	st.set_piece_length(0x4000);
 	st.add_file(combine_path("test", "a"), 10000);
 	TEST_EQUAL(st.paths().size(), 1);
-	TEST_EQUAL(st.paths()[0], "");
+	TEST_EQUAL(st.paths()[0_path], "");
 	st.add_file(combine_path("test", "b"), 20000);
 	TEST_EQUAL(st.paths().size(), 1);
-	TEST_EQUAL(st.paths()[0], "");
+	TEST_EQUAL(st.paths()[0_path], "");
 	st.add_file(combine_path("test", combine_path("c", "a")), 30000);
 	TEST_EQUAL(st.paths().size(), 2);
-	TEST_EQUAL(st.paths()[0], "");
-	TEST_EQUAL(st.paths()[1], "c");
+	TEST_EQUAL(st.paths()[0_path], "");
+	TEST_EQUAL(st.paths()[1_path], "c");
 
 	// make sure that two files with the same path shares the path entry
 	st.add_file(combine_path("test", combine_path("c", "b")), 40000);
 	TEST_EQUAL(st.paths().size(), 2);
-	TEST_EQUAL(st.paths()[0], "");
-	TEST_EQUAL(st.paths()[1], "c");
+	TEST_EQUAL(st.paths()[0_path], "");
+	TEST_EQUAL(st.paths()[1_path], "c");
 
 	// cause pad files to be created, to make sure the pad files also share the
 	// same path entries
 	st.canonicalize();
 
 	TEST_EQUAL(st.paths().size(), 3);
-	TEST_EQUAL(st.paths()[0], "");
-	TEST_EQUAL(st.paths()[1], "c");
-	TEST_EQUAL(st.paths()[2], ".pad");
+	TEST_EQUAL(st.paths()[0_path], "");
+	TEST_EQUAL(st.paths()[1_path], "c");
+	TEST_EQUAL(st.paths()[2_path], ".pad");
 }
 
 TORRENT_TEST(rename_file)


### PR DESCRIPTION
to clear out integer conversions. Technically this isn't really related to v2, but it's a step towards getting the v2 branch build without warnings.