### PR TITLE
simplify torrent::verify_piece() by always checking v2 hashes

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -926,7 +926,7 @@ namespace libtorrent {
 		// we wasn't finished anymore.
 		void resume_download();
 
-		void verify_piece(piece_index_t piece, bool check_v2 = true);
+		void verify_piece(piece_index_t piece);
 		void on_piece_verified(aux::vector<sha256_hash> block_hashes
 			, piece_index_t piece
 			, sha1_hash const& piece_hash, storage_error const& error);

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -10421,7 +10421,7 @@ bool is_downloading_state(int const st)
 
 	// verify piece is used when checking resume data or when the user
 	// adds a piece
-	void torrent::verify_piece(piece_index_t const piece, bool check_v2)
+	void torrent::verify_piece(piece_index_t const piece)
 	{
 //		picker().mark_as_checking(piece);
 
@@ -10431,7 +10431,7 @@ bool is_downloading_state(int const st)
 		if (torrent_file().info_hash().has_v1())
 			flags |= disk_interface::v1_hash;
 		aux::vector<sha256_hash> hashes;
-		if (check_v2 && torrent_file().info_hash().has_v2())
+		if (torrent_file().info_hash().has_v2())
 		{
 			hashes.resize(torrent_file().orig_files().blocks_in_piece2(piece));
 		}


### PR DESCRIPTION
does this make sense?