### PR TITLE
add back deprecated members to announce_endpoint

### DIFF
--- a/include/libtorrent/announce_entry.hpp
+++ b/include/libtorrent/announce_entry.hpp
@@ -130,8 +130,15 @@ TORRENT_VERSION_NAMESPACE_2
 
 	// announces are sent to each tracker using every listen socket
 	// this class holds information about one listen socket for one tracker
+#if TORRENT_ABI_VERSION <= 2
+	// this is to suppress deprecation warnings from implicit move constructor
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+#endif
 	struct TORRENT_EXPORT announce_endpoint
 	{
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 		friend class lt::torrent;
 		friend struct announce_entry;
 
@@ -166,6 +173,19 @@ TORRENT_VERSION_NAMESPACE_2
 		// returns true if the last time we tried to announce to this
 		// tracker succeeded, or if we haven't tried yet.
 		TORRENT_DEPRECATED bool is_working() const;
+
+		// for backwards compatibility
+		time_point32 TORRENT_DEPRECATED_MEMBER next_announce = (time_point32::min)();
+		time_point32 TORRENT_DEPRECATED_MEMBER min_announce = (time_point32::min)();
+		std::string TORRENT_DEPRECATED_MEMBER message;
+		error_code TORRENT_DEPRECATED_MEMBER last_error;
+		int TORRENT_DEPRECATED_MEMBER scrape_incomplete = -1;
+		int TORRENT_DEPRECATED_MEMBER scrape_complete = -1;
+		int TORRENT_DEPRECATED_MEMBER scrape_downloaded = -1;
+		std::uint8_t TORRENT_DEPRECATED_MEMBER fails : 7;
+		bool TORRENT_DEPRECATED_MEMBER updating : 1;
+		bool TORRENT_DEPRECATED_MEMBER start_sent : 1;
+		bool TORRENT_DEPRECATED_MEMBER complete_sent : 1;
 #endif
 
 	private:

--- a/src/announce_entry.cpp
+++ b/src/announce_entry.cpp
@@ -57,6 +57,12 @@ namespace libtorrent {
 
 	announce_endpoint::announce_endpoint(aux::listen_socket_handle const& s)
 		: local_endpoint(s ? s.get_local_endpoint() : tcp::endpoint())
+#if TORRENT_ABI_VERSION <= 2
+		, fails(0)
+		, updating(false)
+		, start_sent(false)
+		, complete_sent(false)
+#endif
 		, socket(s)
 	{}
 
@@ -131,6 +137,12 @@ namespace libtorrent {
 	{
 		for (auto& ih : info_hashes)
 			ih.reset();
+
+#if TORRENT_ABI_VERSION <= 2
+		start_sent = false;
+		next_announce = time_point32::min();
+		min_announce = time_point32::min();
+#endif
 	}
 
 	void announce_entry::reset()

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -2979,6 +2979,12 @@ bool is_downloading_state(int const st)
 				if (aep.socket != req.outgoing_socket) continue;
 				local_endpoint = aep.local_endpoint;
 				aep.info_hashes[hash_version].message = msg;
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				if (hash_version == protocol_version::V1)
+					aep.message = msg;
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 				break;
 			}
 		}
@@ -3011,6 +3017,16 @@ bool is_downloading_state(int const st)
 				if (complete >= 0) aep->info_hashes[hash_version].scrape_complete = complete;
 				if (downloaded >= 0) aep->info_hashes[hash_version].scrape_downloaded = downloaded;
 
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				if (hash_version == protocol_version::V1)
+				{
+					if (incomplete >= 0) aep->scrape_incomplete = incomplete;
+					if (complete >= 0) aep->scrape_complete = complete;
+					if (downloaded >= 0) aep->scrape_downloaded = downloaded;
+				}
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 				update_scrape_state();
 			}
 		}
@@ -3368,6 +3384,14 @@ bool is_downloading_state(int const st)
 						a.min_announce = a.next_announce;
 						a.triggered_manually = true;
 					}
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+					aep.next_announce = (flags & torrent_handle::ignore_min_interval)
+						? time_point_cast<seconds32>(t) + seconds32(1)
+						: std::max(time_point_cast<seconds32>(t), aep.min_announce) + seconds32(1);
+					aep.min_announce = aep.next_announce;
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 				}
 			}
 		}
@@ -3386,6 +3410,14 @@ bool is_downloading_state(int const st)
 					a.min_announce = a.next_announce;
 					a.triggered_manually = true;
 				}
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				aep.next_announce = (flags & torrent_handle::ignore_min_interval)
+					? time_point_cast<seconds32>(t) + seconds32(1)
+					: std::max(time_point_cast<seconds32>(t), aep.min_announce) + seconds32(1);
+				aep.min_announce = aep.next_announce;
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 			}
 		}
 		update_tracker_timer(aux::time_now32());
@@ -5245,8 +5277,15 @@ bool is_downloading_state(int const st)
 			t.endpoints.clear();
 			if (t.source == 0) t.source = announce_entry::source_client;
 			for (auto& aep : t.endpoints)
+			{
 				for (auto& a : aep.info_hashes)
 					a.complete_sent = is_seed();
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				aep.complete_sent = is_seed();
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
+			}
 		}
 
 		if (settings().get_bool(settings_pack::prefer_udp_trackers))
@@ -7672,6 +7711,15 @@ bool is_downloading_state(int const st)
 					a.next_announce = now;
 					a.min_announce = now;
 				}
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				if (!aep.complete_sent)
+				{
+					aep.next_announce = now;
+					aep.min_announce = now;
+				}
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 			}
 		}
 		announce_with_tracker();
@@ -7760,8 +7808,15 @@ bool is_downloading_state(int const st)
 		{
 			for (auto& t : m_trackers)
 				for (auto& aep : t.endpoints)
+				{
 					for (auto& a : aep.info_hashes)
 						a.complete_sent = true;
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+					aep.complete_sent = true;
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
+				}
 
 			if (m_state != torrent_status::finished
 				&& m_state != torrent_status::seeding)
@@ -9196,6 +9251,12 @@ bool is_downloading_state(int const st)
 					a.next_announce = now;
 					a.min_announce = now;
 				}
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+				aep.next_announce = now;
+				aep.min_announce = now;
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
 			}
 		}
 		announce_with_tracker(tracker_request::stopped);
@@ -11205,6 +11266,20 @@ bool is_downloading_state(int const st)
 					a.last_error = ec;
 					a.message = msg;
 					fails = a.fails;
+
+#if TORRENT_ABI_VERSION <= 2
+#include "libtorrent/aux_/disable_warnings_push.hpp"
+					if (hash_version == protocol_version::V1)
+					{
+						aep->fails = a.fails;
+						aep->next_announce = a.next_announce;
+						aep->updating = a.updating;
+						aep->last_error = ec;
+						aep->message = msg;
+					}
+#include "libtorrent/aux_/disable_warnings_pop.hpp"
+#endif
+
 #ifndef TORRENT_DISABLE_LOGGING
 					debug_log("*** increment tracker fail count [%d]", a.fails);
 #endif


### PR DESCRIPTION
is this reasonable? in an attempt to make transitioning to the new libtorrent version easier