### PR TITLE
instead of adding a unit test for the priority hash request feature

### DIFF
--- a/include/libtorrent/hash_picker.hpp
+++ b/include/libtorrent/hash_picker.hpp
@@ -198,7 +198,13 @@ namespace libtorrent
 		file_storage const& m_files;
 		aux::vector<aux::vector<sha256_hash>, file_index_t>& m_merkle_trees;
 		aux::vector<aux::vector<bool>, file_index_t> m_hash_verified;
+
+		// information about every 512-piece span of each file. We request hashes
+		// for 512 pieces at a time
 		aux::vector<aux::vector<piece_hash_request>, file_index_t> m_piece_hash_requested;
+
+		// this is for a future per-block request feature
+#if 0
 		// blocks are only added to this list if there is a time critial block which
 		// has been downloaded but we don't have its hash or if the initial request
 		// for the hash was rejected
@@ -206,10 +212,20 @@ namespace libtorrent
 		// is received
 		// the vector is sorted by the number of requests sent for each block
 		aux::vector<priority_block_request> m_priority_block_requests;
+#endif
+
 		// when a piece fails hash check a request is queued to download the piece's
 		// block hashes
 		aux::vector<piece_block_request> m_piece_block_requests;
+
+		// this is the number of tree levels in a piece. if the piece size is 16
+		// kiB, this is 0, since there is not tree per piece. If the piece size is
+		// 32 kiB, it's 1, and so on.
 		int const m_piece_layer;
+
+		// this is the number of tree layers for a 512-piece range, which is
+		// the granularity with which we send hash requests. The number of layers
+		// all the way down the the block level.
 		int const m_piece_tree_root_layer;
 	};
 } // namespace libtorrent

--- a/include/libtorrent/peer_connection.hpp
+++ b/include/libtorrent/peer_connection.hpp
@@ -763,6 +763,8 @@ namespace aux {
 		void on_seed_mode_hashed(piece_index_t piece
 			, sha1_hash const& piece_hash, aux::vector<sha256_hash> const& block_hashes
 			, storage_error const& error);
+
+		// this is for a future per-block request feature
 #if 0
 		void on_hash2_complete(storage_error const& error, peer_request const& r
 			, sha256_hash const& hash);

--- a/include/libtorrent/piece_picker.hpp
+++ b/include/libtorrent/piece_picker.hpp
@@ -188,6 +188,12 @@ namespace libtorrent {
 			// the number of blocks in the requested state
 			std::uint16_t requested:15;
 
+#if 1
+			// set to 1 if there is an outstanding hash request for this piece
+			std::uint16_t hashing:1;
+
+		// this is for a future per-block request feature
+#else
 			// available for future use
 			std::uint16_t unused:1;
 
@@ -196,6 +202,7 @@ namespace libtorrent {
 
 			// available for future use
 			std::uint16_t unused2:1;
+#endif
 		};
 
 		piece_picker(int blocks_per_piece, int blocks_in_last_piece, int total_num_pieces);

--- a/src/peer_connection.cpp
+++ b/src/peer_connection.cpp
@@ -2965,6 +2965,7 @@ namespace libtorrent {
 //			, peer_info_struct(), block_finished.piece_index, block_finished.block_index);
 		picker.mark_as_writing(block_finished, peer_info_struct());
 
+		// this is for a future per-block request feature
 #if 0
 		if (t->info_hash().has_v2())
 		{
@@ -5388,6 +5389,7 @@ namespace libtorrent {
 		fill_send_buffer();
 	}
 
+		// this is for a future per-block request feature
 #if 0
 	void peer_connection::on_hash2_complete(storage_error const& error
 		, peer_request const& r, sha256_hash const& hash)

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -3265,7 +3265,14 @@ get_out:
 		{
 			auto i = find_dl_piece(p.download_queue(), piece);
 			TORRENT_ASSERT(i != m_downloads[p.download_queue()].end());
+#if 1
+			TORRENT_ASSERT(i->hashing == 0);
+			i->hashing = 1;
+
+			// this is for a future per-block request feature
+#else
 			++i->hashing;
+#endif
 		}
 	}
 
@@ -3280,8 +3287,16 @@ get_out:
 		{
 			auto i = find_dl_piece(p.download_queue(), piece);
 			TORRENT_ASSERT(i != m_downloads[p.download_queue()].end());
+
+#if 1
+			TORRENT_ASSERT(i->hashing == 1);
+			i->hashing = 0;
+
+			// this is for a future per-block request feature
+#else
 			TORRENT_ASSERT(i->hashing > 0);
 			--i->hashing;
+#endif
 		}
 	}
 

--- a/test/test_hash_picker.cpp
+++ b/test/test_hash_picker.cpp
@@ -186,14 +186,12 @@ TORRENT_TEST(reject_piece_request)
 
 	hash_picker picker(fs, trees);
 
-	typed_bitfield<piece_index_t> pieces;
-	pieces.resize(4 * 512);
-	pieces.set_all();
+	typed_bitfield<piece_index_t> const pieces(4 * 512, true);
 
-	auto picked = picker.pick_hashes(pieces);
+	auto const picked = picker.pick_hashes(pieces);
 	picker.hashes_rejected(picked);
 
-	auto picked2 = picker.pick_hashes(pieces);
+	auto const picked2 = picker.pick_hashes(pieces);
 	TEST_CHECK(picked == picked2);
 }
 


### PR DESCRIPTION
comment it out with a comment of the future feature. also comment out the hashing counter in piece picker, as it's also part of the future feature of per-block hash requests