### PR TITLE
fix invalid iterator access in piece_picker::restore_piece

### DIFF
--- a/src/hash_picker.cpp
+++ b/src/hash_picker.cpp
@@ -281,6 +281,8 @@ bool validate_hash_request(hash_request const& hr, file_storage const& fs)
 		if (req.base != m_piece_layer && req.base != 0)
 			return add_hashes_result(false);
 
+		TORRENT_ASSERT(validate_hash_request(req, m_files));
+
 		aux::vector<sha256_hash> tree(merkle_num_nodes(count));
 		std::copy(hashes.begin(), hashes.begin() + req.count, tree.end() - count);
 

--- a/src/piece_picker.cpp
+++ b/src/piece_picker.cpp
@@ -1088,7 +1088,7 @@ namespace libtorrent {
 				info.peer = nullptr;
 				info.state = block_info::state_none;
 			}
-			update_piece_state(i);
+			i = update_piece_state(i);
 		}
 
 		if (blocks.empty() || i->requested + i->finished + i->writing == 0)


### PR DESCRIPTION
the iterator `i` may get invalidated by the call to `update_piece_state()`